### PR TITLE
Rework structure

### DIFF
--- a/__tests__/integration/default_nodemailer_behavior.spec.ts
+++ b/__tests__/integration/default_nodemailer_behavior.spec.ts
@@ -1,9 +1,10 @@
-import { buildNodemailerTransport } from "./helpers/buildNodemailerClient";
+import { buildNodemailerTransport } from "../helpers/buildNodemailerClient";
 import supertest from "supertest";
-import { MAILDEV_API_ENDPOINT } from "./constants/mailDev";
+import { MAILDEV_API_ENDPOINT } from "../constants/mailDev";
+import { join } from "path";
 describe("Default nodemailer behavior", () => {
     it("should send a normal html mail without failing", async () => {
-        const nodeMailerTransport = buildNodemailerTransport({ templateFolder: __dirname });
+        const nodeMailerTransport = buildNodemailerTransport({ templateFolder: join(__dirname, "../resources") });
 
         const mailHtmlContent = "<b>Hello world?</b>";
         await nodeMailerTransport.sendMail({
@@ -22,7 +23,7 @@ describe("Default nodemailer behavior", () => {
     });
 
     it("should send a normal text mail without failing", async () => {
-        const nodeMailerTransport = buildNodemailerTransport({ templateFolder: __dirname });
+        const nodeMailerTransport = buildNodemailerTransport({ templateFolder: join(__dirname, "../resources") });
 
         const mailTextContent = "Hello world?";
         await nodeMailerTransport.sendMail({

--- a/__tests__/unit/buildMjmlTemplate.spec.ts
+++ b/__tests__/unit/buildMjmlTemplate.spec.ts
@@ -1,0 +1,55 @@
+import { join } from "path";
+import { buildMjmlTemplate } from "../../src";
+
+describe("buildMjmlTemplate", () => {
+
+    it("should fail if template folder does not exist", async () => {
+        await expect(buildMjmlTemplate({
+            templateFolder: join(__dirname, "folderThatDoesNotExist"),
+        }, "templateThatDoesNotExist")).rejects.toThrow();
+    });
+
+    it("should fail if template does not exist", async () => {
+        await expect(buildMjmlTemplate({
+            templateFolder: join(__dirname, "../resources"),
+        }, "templateThatDoesNotExist")).rejects.toThrow();
+    });
+
+    it("should fail if mjml template is invalid", async () => {
+        await expect(buildMjmlTemplate({
+            templateFolder: join(__dirname, "../resources"),
+        }, "test-invalid")).rejects.toThrow();
+    });
+
+    it("should compile a template without template data", async() => {
+        const mailHtmlContent = await buildMjmlTemplate({
+            templateFolder: join(__dirname, "../resources"),
+        }, "test");
+
+        expect(mailHtmlContent).toBeDefined();
+    });
+
+    it("should compile a template with template data and html content should be replaced", async() => {
+        const mailHtmlContent = await buildMjmlTemplate({
+            templateFolder: join(__dirname, "../resources"),
+        }, "test-mustache",  {
+            testKey: "testKey",
+            testKeyNested: {
+                nestedKey: "nestedKey"
+            }
+        });
+
+        expect(mailHtmlContent).toBeDefined();
+        expect(mailHtmlContent).toContain("testKey");
+        expect(mailHtmlContent).toContain("nestedKey");
+    });
+
+    it("should compile a template using mjml-include tag", async() => {
+        const mailHtmlContent = await buildMjmlTemplate({
+            templateFolder: join(__dirname, "../resources"),
+        }, "test-include/test-include");
+
+        expect(mailHtmlContent).toBeDefined();
+        expect(mailHtmlContent).toContain("This is a header");
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import type { IPluginOptions } from "./types/IPluginsOptions";
 declare module 'nodemailer/lib/mailer' {
     interface Options {
         templateName?: string;
-        templateData?: Record<any, any>
+        templateData?: Record<never, never>
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { PluginFunction } from "nodemailer/lib/mailer";
 import type MailMessage from "nodemailer/lib/mailer/mail-message";
 import { buildMjmlTemplate } from "./helpers/buildMjmlTemplate";
 import type { IPluginOptions } from "./types/IPluginsOptions";
@@ -8,8 +9,8 @@ declare module 'nodemailer/lib/mailer' {
     }
 }
 
-const nodemailerMjmlPlugin = (options: IPluginOptions) => {
-    return async (mail: MailMessage, callback: (err?: unknown) => void) => {
+const nodemailerMjmlPlugin = (options: IPluginOptions): PluginFunction => {
+    return async (mail: MailMessage, callback: (err?: Error | null) => void) => {
         if (mail.data.html || !mail.data?.templateName) return callback();
 
         try {
@@ -19,7 +20,7 @@ const nodemailerMjmlPlugin = (options: IPluginOptions) => {
             Object.assign(mail.data, { html: mailHtmlContent });
             return callback();
         } catch (error) {
-            return callback(error);
+            return callback(error as Error | null);
         }
     };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,23 @@ declare module 'nodemailer/lib/mailer' {
 }
 
 const nodemailerMjmlPlugin = (options: IPluginOptions) => {
-    return (mail: MailMessage, callback: () => void)  =>{
-        return buildMjmlTemplate(options, mail, callback);
+    return async (mail: MailMessage, callback: (err?: unknown) => void) => {
+        if (mail.data.html || !mail.data?.templateName) return callback();
+
+        try {
+            const { templateData, templateName } = mail.data;
+            const mailHtmlContent = await buildMjmlTemplate(options, templateName, templateData);
+
+            Object.assign(mail.data, { html: mailHtmlContent });
+            return callback();
+        } catch (error) {
+            return callback(error);
+        }
     };
 };
 
 export default nodemailerMjmlPlugin;
+
 export {
     nodemailerMjmlPlugin,
     buildMjmlTemplate,


### PR DESCRIPTION
This pr introduce the rework of `buildMjmlTemplate` function in order to separate the build and compile of mjml template with the populate of nodemailer mail content. 
This refactor allow to write better test and have a better separation layer between mjml and this plugin